### PR TITLE
Fix creating profile, can't know ID

### DIFF
--- a/nextdns/resource_nextdns_profile.go
+++ b/nextdns/resource_nextdns_profile.go
@@ -26,25 +26,19 @@ func resourceNextDNSProfile() *schema.Resource {
 
 func resourceNextDNSProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*nextdns.Client)
-	profileID := d.Get("profile_id").(string)
 
-	profile := &nextdns.Profile{
+	request := &nextdns.CreateProfileRequest{
 		Name: d.Get("name").(string),
-	}
-	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", profile))
-
-	request := &nextdns.UpdateProfileRequest{
-		ProfileID: profileID,
-		Profile:   profile,
 	}
 	tflog.Debug(ctx, fmt.Sprintf("request to nextdns api: %+v", request))
 
-	err := client.Profiles.Update(ctx, request)
+	profileID, err := client.Profiles.Create(ctx, request)
 	if err != nil {
 		return diag.FromErr(errors.Wrap(err, "error creating profile"))
 	}
 
 	d.SetId(profileID)
+	d.Set("profile_id", profileID)
 
 	return resourceNextDNSProfileRead(ctx, d, meta)
 }

--- a/nextdns/schema_nextdns_profile.go
+++ b/nextdns/schema_nextdns_profile.go
@@ -9,7 +9,7 @@ func resourceNextDNSProfileSchema() map[string]*schema.Schema {
 		"profile_id": {
 			Description: "The profile identifier to target the resource.",
 			Type:        schema.TypeString,
-			Required:    true,
+			Computed:    true,
 		},
 		"name": {
 			Description: "Profile name.",


### PR DESCRIPTION
The profile_id should be computed, since it's generated by NextDNS - we can't supply one when creating a profile (and indeed it didn't try, just updated the name on an existing profile, so you'd have had to create it manually, copy the ID, not import it, and then let it 'create' it by just changing the name from whatever you set manually).