### PR TITLE
Implement DNS endpoint computed attrs

### DIFF
--- a/nextdns/schema_nextdns_profile.go
+++ b/nextdns/schema_nextdns_profile.go
@@ -6,6 +6,22 @@ import (
 
 func resourceNextDNSProfileSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"endpoint_doh": {
+			Description: "The DNS over HTTPS address the DNS is reachable at.",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"endpoint_dot": {
+			Description: "The DNS over TLS address the DNS is reachable at.",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"endpoint_ipv6": {
+			Description: "The IPv6 addresses the DNS is reachable at.",
+			Type:        schema.TypeList,
+			Elem:        schema.TypeString,
+			Computed:    true,
+		},
 		"profile_id": {
 			Description: "The profile identifier to target the resource.",
 			Type:        schema.TypeString,


### PR DESCRIPTION
These are purely derived from the profile ID, so arguably it's not necessary/not a property of the resource - but IMO it's a lot more convenient/ergonomic to use downstream than trying to do the manipulation (particularly for the IPv6 addresses, which was what I needed) with terraform functions.