### PR TITLE
feat: replace `github.com/pkg/errors` with builtin errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,3 +29,7 @@ linters-settings:
     exclude-functions:
       # tfproviderlint covers the errcheck.
       - (*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.ResourceData).Set
+  depguard:
+    list-type: 'denylist'
+    packages-with-error-message:
+      - 'github.com/pkg/errors': 'the github.com/pkg/errors is deprecated, use stdlib instead'

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/amalucelli/nextdns-go v0.4.0
 	github.com/hashicorp/terraform-plugin-log v0.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
-	github.com/pkg/errors v0.9.1
 )
 
 require (
@@ -42,6 +41,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect

--- a/nextdns/resource_nextdns_allowlist.go
+++ b/nextdns/resource_nextdns_allowlist.go
@@ -2,13 +2,13 @@ package nextdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/amalucelli/nextdns-go/nextdns"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 )
 
 func resourceNextDNSAllowlist() *schema.Resource {
@@ -30,7 +30,7 @@ func resourceNextDNSAllowlistCreate(ctx context.Context, d *schema.ResourceData,
 
 	allowlist, err := buildAllowlist(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error building allow list"))
+		return diag.FromErr(fmt.Errorf("error building allow list: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", allowlist))
 
@@ -42,7 +42,7 @@ func resourceNextDNSAllowlistCreate(ctx context.Context, d *schema.ResourceData,
 
 	err = client.Allowlist.Create(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating allow list"))
+		return diag.FromErr(fmt.Errorf("error creating allow list: %w", err))
 	}
 
 	d.SetId(profileID)
@@ -61,7 +61,7 @@ func resourceNextDNSAllowlistRead(ctx context.Context, d *schema.ResourceData, m
 
 	allowlist, err := client.Allowlist.List(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting allow list"))
+		return diag.FromErr(fmt.Errorf("error getting allow list: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", allowlist))
 
@@ -89,7 +89,7 @@ func resourceNextDNSAllowlistUpdate(ctx context.Context, d *schema.ResourceData,
 
 	allowlist, err := buildAllowlist(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error building allow list"))
+		return diag.FromErr(fmt.Errorf("error building allow list: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", allowlist))
 
@@ -101,7 +101,7 @@ func resourceNextDNSAllowlistUpdate(ctx context.Context, d *schema.ResourceData,
 
 	err = client.Allowlist.Create(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating allow list"))
+		return diag.FromErr(fmt.Errorf("error updating allow list: %w", err))
 	}
 
 	return resourceNextDNSAllowlistRead(ctx, d, meta)
@@ -119,7 +119,7 @@ func resourceNextDNSAllowlistDelete(ctx context.Context, d *schema.ResourceData,
 
 	err := client.Allowlist.Create(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting allow list"))
+		return diag.FromErr(fmt.Errorf("error deleting allow list: %w", err))
 	}
 
 	return resourceNextDNSAllowlistRead(ctx, d, meta)
@@ -138,6 +138,7 @@ func resourceNextDNSAllowlistImport(ctx context.Context, d *schema.ResourceData,
 func buildAllowlist(d *schema.ResourceData) ([]*nextdns.Allowlist, error) {
 	found, ok := d.GetOk("domain")
 	if !ok {
+		// nolint:goerr113
 		return nil, errors.New("unable to find domain in resource data")
 	}
 

--- a/nextdns/resource_nextdns_denylist.go
+++ b/nextdns/resource_nextdns_denylist.go
@@ -2,13 +2,13 @@ package nextdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/amalucelli/nextdns-go/nextdns"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 )
 
 func resourceNextDNSDenylist() *schema.Resource {
@@ -30,7 +30,7 @@ func resourceNextDNSDenylistCreate(ctx context.Context, d *schema.ResourceData, 
 
 	denylist, err := buildDenylist(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error building deny list"))
+		return diag.FromErr(fmt.Errorf("error building deny list: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", denylist))
 
@@ -42,7 +42,7 @@ func resourceNextDNSDenylistCreate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.Denylist.Create(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating deny list"))
+		return diag.FromErr(fmt.Errorf("error creating deny list: %w", err))
 	}
 
 	d.SetId(profileID)
@@ -61,7 +61,7 @@ func resourceNextDNSDenylistRead(ctx context.Context, d *schema.ResourceData, me
 
 	denylist, err := client.Denylist.List(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting deny list"))
+		return diag.FromErr(fmt.Errorf("error getting deny list: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", denylist))
 
@@ -89,7 +89,7 @@ func resourceNextDNSDenylistUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	denylist, err := buildDenylist(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error building deny list"))
+		return diag.FromErr(fmt.Errorf("error building deny list: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", denylist))
 
@@ -101,7 +101,7 @@ func resourceNextDNSDenylistUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.Denylist.Create(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating deny list"))
+		return diag.FromErr(fmt.Errorf("error updating deny list: %w", err))
 	}
 
 	return resourceNextDNSDenylistRead(ctx, d, meta)
@@ -119,7 +119,7 @@ func resourceNextDNSDenylistDelete(ctx context.Context, d *schema.ResourceData, 
 
 	err := client.Denylist.Create(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting deny list"))
+		return diag.FromErr(fmt.Errorf("error deleting deny list: %w", err))
 	}
 
 	return resourceNextDNSDenylistRead(ctx, d, meta)
@@ -138,6 +138,7 @@ func resourceNextDNSDenylistImport(ctx context.Context, d *schema.ResourceData, 
 func buildDenylist(d *schema.ResourceData) ([]*nextdns.Denylist, error) {
 	found, ok := d.GetOk("domain")
 	if !ok {
+		// nolint:goerr113
 		return nil, errors.New("unable to find domain in resource data")
 	}
 

--- a/nextdns/resource_nextdns_parentalcontrol.go
+++ b/nextdns/resource_nextdns_parentalcontrol.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 )
 
 func resourceNextDNSParentalControl() *schema.Resource {
@@ -30,7 +29,7 @@ func resourceNextDNSParentalControlCreate(ctx context.Context, d *schema.Resourc
 
 	parentalControl, err := buildParentalControl(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating parental control settings"))
+		return diag.FromErr(fmt.Errorf("error creating parental control settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", parentalControl))
 
@@ -42,7 +41,7 @@ func resourceNextDNSParentalControlCreate(ctx context.Context, d *schema.Resourc
 
 	err = client.ParentalControlServices.Create(ctx, services)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating services settings"))
+		return diag.FromErr(fmt.Errorf("error creating services settings: %w", err))
 	}
 
 	categories := &nextdns.CreateParentalControlCategoriesRequest{
@@ -53,7 +52,7 @@ func resourceNextDNSParentalControlCreate(ctx context.Context, d *schema.Resourc
 
 	err = client.ParentalControlCategories.Create(ctx, categories)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating categories settings"))
+		return diag.FromErr(fmt.Errorf("error creating categories settings: %w", err))
 	}
 
 	request := &nextdns.UpdateParentalControlRequest{
@@ -64,7 +63,7 @@ func resourceNextDNSParentalControlCreate(ctx context.Context, d *schema.Resourc
 
 	err = client.ParentalControl.Update(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating parental control settings"))
+		return diag.FromErr(fmt.Errorf("error creating parental control settings: %w", err))
 	}
 
 	d.SetId(profileID)
@@ -83,7 +82,7 @@ func resourceNextDNSParentalControlRead(ctx context.Context, d *schema.ResourceD
 
 	parentalControl, err := client.ParentalControl.Get(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting parental control settings"))
+		return diag.FromErr(fmt.Errorf("error getting parental control settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", parentalControl))
 
@@ -192,7 +191,7 @@ func resourceNextDNSParentalControlUpdate(ctx context.Context, d *schema.Resourc
 
 	parentalControl, err := buildParentalControl(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating parental control settings"))
+		return diag.FromErr(fmt.Errorf("error updating parental control settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", parentalControl))
 
@@ -204,7 +203,7 @@ func resourceNextDNSParentalControlUpdate(ctx context.Context, d *schema.Resourc
 
 	err = client.ParentalControlServices.Create(ctx, services)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating services settings"))
+		return diag.FromErr(fmt.Errorf("error updating services settings: %w", err))
 	}
 
 	categories := &nextdns.CreateParentalControlCategoriesRequest{
@@ -215,7 +214,7 @@ func resourceNextDNSParentalControlUpdate(ctx context.Context, d *schema.Resourc
 
 	err = client.ParentalControlCategories.Create(ctx, categories)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating categories settings"))
+		return diag.FromErr(fmt.Errorf("error updating categories settings: %w", err))
 	}
 
 	request := &nextdns.UpdateParentalControlRequest{
@@ -226,7 +225,7 @@ func resourceNextDNSParentalControlUpdate(ctx context.Context, d *schema.Resourc
 
 	err = client.ParentalControl.Update(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating parental control settings"))
+		return diag.FromErr(fmt.Errorf("error updating parental control settings: %w", err))
 	}
 
 	return resourceNextDNSParentalControlRead(ctx, d, meta)
@@ -244,7 +243,7 @@ func resourceNextDNSParentalControlDelete(ctx context.Context, d *schema.Resourc
 
 	err := client.ParentalControlServices.Create(ctx, services)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting services settings"))
+		return diag.FromErr(fmt.Errorf("error deleting services settings: %w", err))
 	}
 
 	categories := &nextdns.CreateParentalControlCategoriesRequest{
@@ -255,7 +254,7 @@ func resourceNextDNSParentalControlDelete(ctx context.Context, d *schema.Resourc
 
 	err = client.ParentalControlCategories.Create(ctx, categories)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting categories settings"))
+		return diag.FromErr(fmt.Errorf("error deleting categories settings: %w", err))
 	}
 
 	parentalControl := &nextdns.UpdateParentalControlRequest{
@@ -266,7 +265,7 @@ func resourceNextDNSParentalControlDelete(ctx context.Context, d *schema.Resourc
 
 	err = client.ParentalControl.Update(ctx, parentalControl)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting parental control settings"))
+		return diag.FromErr(fmt.Errorf("error deleting parental control settings: %w", err))
 	}
 
 	return resourceNextDNSParentalControlRead(ctx, d, meta)

--- a/nextdns/resource_nextdns_privacy.go
+++ b/nextdns/resource_nextdns_privacy.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 )
 
 func resourceNextDNSPrivacy() *schema.Resource {
@@ -30,7 +29,7 @@ func resourceNextDNSPrivacyCreate(ctx context.Context, d *schema.ResourceData, m
 
 	privacy, err := buildPrivacy(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating privacy settings"))
+		return diag.FromErr(fmt.Errorf("error creating privacy settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", privacy))
 
@@ -42,7 +41,7 @@ func resourceNextDNSPrivacyCreate(ctx context.Context, d *schema.ResourceData, m
 
 	err = client.PrivacyBlocklists.Create(ctx, blocklist)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating blocklist settings"))
+		return diag.FromErr(fmt.Errorf("error creating blocklist settings: %w", err))
 	}
 
 	natives := &nextdns.CreatePrivacyNativesRequest{
@@ -53,7 +52,7 @@ func resourceNextDNSPrivacyCreate(ctx context.Context, d *schema.ResourceData, m
 
 	err = client.PrivacyNatives.Create(ctx, natives)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating native settings"))
+		return diag.FromErr(fmt.Errorf("error creating native settings: %w", err))
 	}
 
 	request := &nextdns.UpdatePrivacyRequest{
@@ -64,7 +63,7 @@ func resourceNextDNSPrivacyCreate(ctx context.Context, d *schema.ResourceData, m
 
 	err = client.Privacy.Update(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating privacy settings"))
+		return diag.FromErr(fmt.Errorf("error creating privacy settings: %w", err))
 	}
 	d.SetId(profileID)
 
@@ -80,7 +79,7 @@ func resourceNextDNSPrivacyRead(ctx context.Context, d *schema.ResourceData, met
 	}
 	privacy, err := client.Privacy.Get(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting privacy settings"))
+		return diag.FromErr(fmt.Errorf("error getting privacy settings: %w", err))
 	}
 
 	d.SetId(profileID)
@@ -99,7 +98,7 @@ func resourceNextDNSPrivacyUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	privacy, err := buildPrivacy(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating privacy settings"))
+		return diag.FromErr(fmt.Errorf("error updating privacy settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", privacy))
 
@@ -111,7 +110,7 @@ func resourceNextDNSPrivacyUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	err = client.PrivacyBlocklists.Create(ctx, blocklist)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting blocklist settings"))
+		return diag.FromErr(fmt.Errorf("error deleting blocklist settings: %w", err))
 	}
 
 	natives := &nextdns.CreatePrivacyNativesRequest{
@@ -122,7 +121,7 @@ func resourceNextDNSPrivacyUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	err = client.PrivacyNatives.Create(ctx, natives)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting native settings"))
+		return diag.FromErr(fmt.Errorf("error deleting native settings: %w", err))
 	}
 
 	request := &nextdns.UpdatePrivacyRequest{
@@ -133,7 +132,7 @@ func resourceNextDNSPrivacyUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	err = client.Privacy.Update(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting privacy settings"))
+		return diag.FromErr(fmt.Errorf("error deleting privacy settings: %w", err))
 	}
 
 	return resourceNextDNSPrivacyRead(ctx, d, meta)
@@ -151,7 +150,7 @@ func resourceNextDNSPrivacyDelete(ctx context.Context, d *schema.ResourceData, m
 
 	err := client.PrivacyBlocklists.Create(ctx, blocklist)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting blocklist settings"))
+		return diag.FromErr(fmt.Errorf("error deleting blocklist settings: %w", err))
 	}
 
 	natives := &nextdns.CreatePrivacyNativesRequest{
@@ -162,7 +161,7 @@ func resourceNextDNSPrivacyDelete(ctx context.Context, d *schema.ResourceData, m
 
 	err = client.PrivacyNatives.Create(ctx, natives)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting native settings"))
+		return diag.FromErr(fmt.Errorf("error deleting native settings: %w", err))
 	}
 
 	privacy := &nextdns.UpdatePrivacyRequest{
@@ -173,7 +172,7 @@ func resourceNextDNSPrivacyDelete(ctx context.Context, d *schema.ResourceData, m
 
 	err = client.Privacy.Update(ctx, privacy)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting privacy settings"))
+		return diag.FromErr(fmt.Errorf("error deleting privacy settings: %w", err))
 	}
 
 	return resourceNextDNSPrivacyRead(ctx, d, meta)

--- a/nextdns/resource_nextdns_profile.go
+++ b/nextdns/resource_nextdns_profile.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 )
 
 func resourceNextDNSProfile() *schema.Resource {
@@ -34,7 +33,7 @@ func resourceNextDNSProfileCreate(ctx context.Context, d *schema.ResourceData, m
 
 	profileID, err := client.Profiles.Create(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating profile"))
+		return diag.FromErr(fmt.Errorf("error creating profile: %w", err))
 	}
 
 	d.SetId(profileID)
@@ -54,7 +53,7 @@ func resourceNextDNSProfileRead(ctx context.Context, d *schema.ResourceData, met
 
 	profile, err := client.Profiles.Get(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting profile"))
+		return diag.FromErr(fmt.Errorf("error getting profile: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", profile))
 
@@ -84,7 +83,7 @@ func resourceNextDNSProfileUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	err := client.Profiles.Update(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating profile"))
+		return diag.FromErr(fmt.Errorf("error updating profile: %w", err))
 	}
 
 	return resourceNextDNSProfileRead(ctx, d, meta)
@@ -101,7 +100,7 @@ func resourceNextDNSProfileDelete(ctx context.Context, d *schema.ResourceData, m
 
 	err := client.Profiles.Delete(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting profile"))
+		return diag.FromErr(fmt.Errorf("error deleting profile: %w", err))
 	}
 
 	return nil

--- a/nextdns/resource_nextdns_rewrite.go
+++ b/nextdns/resource_nextdns_rewrite.go
@@ -2,13 +2,13 @@ package nextdns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/amalucelli/nextdns-go/nextdns"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 )
 
 func resourceNextDNSRewrite() *schema.Resource {
@@ -30,7 +30,7 @@ func resourceNextDNSRewriteCreate(ctx context.Context, d *schema.ResourceData, m
 
 	rewrites, err := buildRewrite(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error building rewrite list"))
+		return diag.FromErr(fmt.Errorf("error building rewrite list: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", rewrites))
 
@@ -41,7 +41,7 @@ func resourceNextDNSRewriteCreate(ctx context.Context, d *schema.ResourceData, m
 
 	existing, err := client.Rewrites.List(ctx, list)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting rewrites"))
+		return diag.FromErr(fmt.Errorf("error getting rewrites: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", rewrites))
 
@@ -60,7 +60,7 @@ func resourceNextDNSRewriteCreate(ctx context.Context, d *schema.ResourceData, m
 
 				err := client.Rewrites.Delete(ctx, deleteRequest)
 				if err != nil {
-					return diag.FromErr(errors.Wrap(err, "error deleting rewrite"))
+					return diag.FromErr(fmt.Errorf("error deleting rewrite: %w", err))
 				}
 
 				continue
@@ -77,7 +77,7 @@ func resourceNextDNSRewriteCreate(ctx context.Context, d *schema.ResourceData, m
 
 		_, err = client.Rewrites.Create(ctx, request)
 		if err != nil {
-			return diag.FromErr(errors.Wrap(err, "error creating rewrite"))
+			return diag.FromErr(fmt.Errorf("error creating rewrite: %w", err))
 		}
 	}
 
@@ -97,7 +97,7 @@ func resourceNextDNSRewriteRead(ctx context.Context, d *schema.ResourceData, met
 
 	rewrites, err := client.Rewrites.List(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting rewrites"))
+		return diag.FromErr(fmt.Errorf("error getting rewrites: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", rewrites))
 
@@ -125,7 +125,7 @@ func resourceNextDNSRewriteUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	rewrites, err := buildRewrite(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error building rewrite list"))
+		return diag.FromErr(fmt.Errorf("error building rewrite list: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", rewrites))
 
@@ -136,7 +136,7 @@ func resourceNextDNSRewriteUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	existing, err := client.Rewrites.List(ctx, list)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting rewrites"))
+		return diag.FromErr(fmt.Errorf("error getting rewrites: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", rewrites))
 
@@ -178,7 +178,7 @@ func resourceNextDNSRewriteUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		err := client.Rewrites.Delete(ctx, deleteRequest)
 		if err != nil {
-			return diag.FromErr(errors.Wrap(err, "error deleting rewrite"))
+			return diag.FromErr(fmt.Errorf("error deleting rewrite: %w", err))
 		}
 	}
 
@@ -191,7 +191,7 @@ func resourceNextDNSRewriteUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		_, err = client.Rewrites.Create(ctx, request)
 		if err != nil {
-			return diag.FromErr(errors.Wrap(err, "error creating rewrite"))
+			return diag.FromErr(fmt.Errorf("error creating rewrite: %w", err))
 		}
 	}
 
@@ -209,7 +209,7 @@ func resourceNextDNSRewriteDelete(ctx context.Context, d *schema.ResourceData, m
 
 	rewrites, err := client.Rewrites.List(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting rewrites"))
+		return diag.FromErr(fmt.Errorf("error getting rewrites: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", rewrites))
 
@@ -222,7 +222,7 @@ func resourceNextDNSRewriteDelete(ctx context.Context, d *schema.ResourceData, m
 
 		err = client.Rewrites.Delete(ctx, request)
 		if err != nil {
-			return diag.FromErr(errors.Wrap(err, "error deleting rewrite"))
+			return diag.FromErr(fmt.Errorf("error deleting rewrite: %w", err))
 		}
 	}
 
@@ -242,6 +242,7 @@ func resourceNextDNSRewriteImport(ctx context.Context, d *schema.ResourceData, m
 func buildRewrite(d *schema.ResourceData) ([]*nextdns.Rewrites, error) {
 	found, ok := d.GetOk("rewrite")
 	if !ok {
+		// nolint:goerr113
 		return nil, errors.New("unable to find rewrite in resource data")
 	}
 

--- a/nextdns/resource_nextdns_security.go
+++ b/nextdns/resource_nextdns_security.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 )
 
 func resourceNextDNSSecurity() *schema.Resource {
@@ -30,7 +29,7 @@ func resourceNextDNSSecurityCreate(ctx context.Context, d *schema.ResourceData, 
 
 	sec, err := buildSecurity(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating security settings"))
+		return diag.FromErr(fmt.Errorf("error creating security settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", sec))
 
@@ -42,7 +41,7 @@ func resourceNextDNSSecurityCreate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SecurityTlds.Create(ctx, tlds)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating security tlds settings"))
+		return diag.FromErr(fmt.Errorf("error creating security tlds settings: %w", err))
 	}
 
 	request := &nextdns.UpdateSecurityRequest{
@@ -53,7 +52,7 @@ func resourceNextDNSSecurityCreate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.Security.Update(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating security settings"))
+		return diag.FromErr(fmt.Errorf("error creating security settings: %w", err))
 	}
 
 	d.SetId(profileID)
@@ -70,7 +69,7 @@ func resourceNextDNSSecurityRead(ctx context.Context, d *schema.ResourceData, me
 	}
 	security, err := client.Security.Get(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting security settings"))
+		return diag.FromErr(fmt.Errorf("error getting security settings: %w", err))
 	}
 
 	d.SetId(profileID)
@@ -98,7 +97,7 @@ func resourceNextDNSSecurityUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	sec, err := buildSecurity(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating security settings"))
+		return diag.FromErr(fmt.Errorf("error updating security settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", sec))
 
@@ -110,7 +109,7 @@ func resourceNextDNSSecurityUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SecurityTlds.Create(ctx, tlds)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating security tlds settings"))
+		return diag.FromErr(fmt.Errorf("error updating security tlds settings: %w", err))
 	}
 
 	request := &nextdns.UpdateSecurityRequest{
@@ -121,7 +120,7 @@ func resourceNextDNSSecurityUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.Security.Update(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error updating security settings"))
+		return diag.FromErr(fmt.Errorf("error updating security settings: %w", err))
 	}
 
 	return resourceNextDNSSecurityRead(ctx, d, meta)
@@ -139,7 +138,7 @@ func resourceNextDNSSecurityDelete(ctx context.Context, d *schema.ResourceData, 
 
 	err := client.SecurityTlds.Create(ctx, tlds)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting security tlds settings"))
+		return diag.FromErr(fmt.Errorf("error deleting security tlds settings: %w", err))
 	}
 
 	sec := &nextdns.UpdateSecurityRequest{
@@ -150,7 +149,7 @@ func resourceNextDNSSecurityDelete(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.Security.Update(ctx, sec)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting security settings"))
+		return diag.FromErr(fmt.Errorf("error deleting security settings: %w", err))
 	}
 
 	return resourceNextDNSSecurityRead(ctx, d, meta)

--- a/nextdns/resource_nextdns_settings.go
+++ b/nextdns/resource_nextdns_settings.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/pkg/errors"
 )
 
 func resourceNextDNSSettings() *schema.Resource {
@@ -31,7 +30,7 @@ func resourceNextDNSSettingsCreate(ctx context.Context, d *schema.ResourceData, 
 
 	settings, err := buildSettings(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating settings"))
+		return diag.FromErr(fmt.Errorf("error creating settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", settings))
 
@@ -43,7 +42,7 @@ func resourceNextDNSSettingsCreate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SettingsLogs.Update(ctx, logs)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating logs settings"))
+		return diag.FromErr(fmt.Errorf("error creating logs settings: %w", err))
 	}
 
 	blockPage := &nextdns.UpdateSettingsBlockPageRequest{
@@ -54,7 +53,7 @@ func resourceNextDNSSettingsCreate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SettingsBlockPage.Update(ctx, blockPage)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating categories settings"))
+		return diag.FromErr(fmt.Errorf("error creating categories settings: %w", err))
 	}
 
 	performance := &nextdns.UpdateSettingsPerformanceRequest{
@@ -65,7 +64,7 @@ func resourceNextDNSSettingsCreate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SettingsPerformance.Update(ctx, performance)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating categories settings"))
+		return diag.FromErr(fmt.Errorf("error creating categories settings: %w", err))
 	}
 
 	request := &nextdns.UpdateSettingsRequest{
@@ -76,7 +75,7 @@ func resourceNextDNSSettingsCreate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.Settings.Update(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating parental control settings"))
+		return diag.FromErr(fmt.Errorf("error creating parental control settings: %w", err))
 	}
 
 	d.SetId(profileID)
@@ -95,7 +94,7 @@ func resourceNextDNSSettingsRead(ctx context.Context, d *schema.ResourceData, me
 
 	settings, err := client.Settings.Get(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error getting settings"))
+		return diag.FromErr(fmt.Errorf("error getting settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", settings))
 
@@ -137,7 +136,7 @@ func resourceNextDNSSettingsUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	settings, err := buildSettings(d)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating settings"))
+		return diag.FromErr(fmt.Errorf("error creating settings: %w", err))
 	}
 	tflog.Debug(ctx, fmt.Sprintf("object built: %+v", settings))
 
@@ -149,7 +148,7 @@ func resourceNextDNSSettingsUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SettingsLogs.Update(ctx, logs)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating logs settings"))
+		return diag.FromErr(fmt.Errorf("error creating logs settings: %w", err))
 	}
 
 	blockPage := &nextdns.UpdateSettingsBlockPageRequest{
@@ -160,7 +159,7 @@ func resourceNextDNSSettingsUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SettingsBlockPage.Update(ctx, blockPage)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating categories settings"))
+		return diag.FromErr(fmt.Errorf("error creating categories settings: %w", err))
 	}
 
 	performance := &nextdns.UpdateSettingsPerformanceRequest{
@@ -171,7 +170,7 @@ func resourceNextDNSSettingsUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SettingsPerformance.Update(ctx, performance)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating categories settings"))
+		return diag.FromErr(fmt.Errorf("error creating categories settings: %w", err))
 	}
 
 	request := &nextdns.UpdateSettingsRequest{
@@ -182,7 +181,7 @@ func resourceNextDNSSettingsUpdate(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.Settings.Update(ctx, request)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error creating parental control settings"))
+		return diag.FromErr(fmt.Errorf("error creating parental control settings: %w", err))
 	}
 
 	return resourceNextDNSSettingsRead(ctx, d, meta)
@@ -200,7 +199,7 @@ func resourceNextDNSSettingsDelete(ctx context.Context, d *schema.ResourceData, 
 
 	err := client.SettingsLogs.Update(ctx, logs)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting logs settings"))
+		return diag.FromErr(fmt.Errorf("error deleting logs settings: %w", err))
 	}
 
 	blockPage := &nextdns.UpdateSettingsBlockPageRequest{
@@ -211,7 +210,7 @@ func resourceNextDNSSettingsDelete(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SettingsBlockPage.Update(ctx, blockPage)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting block page settings"))
+		return diag.FromErr(fmt.Errorf("error deleting block page settings: %w", err))
 	}
 
 	performance := &nextdns.UpdateSettingsPerformanceRequest{
@@ -222,7 +221,7 @@ func resourceNextDNSSettingsDelete(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.SettingsPerformance.Update(ctx, performance)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting performance settings"))
+		return diag.FromErr(fmt.Errorf("error deleting performance settings: %w", err))
 	}
 
 	settings := &nextdns.UpdateSettingsRequest{
@@ -233,7 +232,7 @@ func resourceNextDNSSettingsDelete(ctx context.Context, d *schema.ResourceData, 
 
 	err = client.Settings.Update(ctx, settings)
 	if err != nil {
-		return diag.FromErr(errors.Wrap(err, "error deleting settings"))
+		return diag.FromErr(fmt.Errorf("error deleting settings: %w", err))
 	}
 
 	return resourceNextDNSSettingsRead(ctx, d, meta)


### PR DESCRIPTION
The standard library now has built-in support for wrapping and unwrapping error values.

This change replaces all uses of `github.com/pkg/errors` with the standard library since the former is now deprecated.